### PR TITLE
Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/java",
-      "version_requirement": ">= 1.4.2 < 8.0.0"
+      "version_requirement": ">= 1.4.2 < 10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
puppetlabs/java < 10

#### Pull Request (PR) description
Increase the dependency version of puppetlabs/java from < 8 to < 10.

#### This Pull Request (PR) fixes the following issues
The java::adoptium defined type doesn't exist in the version we're currently limited to.